### PR TITLE
Prefer createEmployeeRecords => createEmployees

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ the function returns.
     _Additionally_, initialize empty `Array`s on the properties `timeInEvents`
     and `timeOutEvents`.
 
-### `createEmployees`
+### `createEmployeeRecords`
 
  * **Argument(s)**
   * `Array` of `Arrays`
@@ -262,16 +262,6 @@ the function returns.
   * Using `wagesEarnedOnDate`, accumulate the value of all dates worked by the
     employee in the record used as context. Amount should be returned as a
     number. **HINT**: You will need to find the available dates somehow...
-
-### `createEmployeeRecords`
-
-* **Argument(s)**
-  * `Array` of `Arrays`
-* **Returns**
-  * `Array` of `Object`s
-* **Behavior**
-  * Converts each nested `Array` into an employee record using
-    `createEmployeeRecord` and accumulates it to a new `Array`
 
 ### `findEmployeeByFirstName`
 

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -38,11 +38,11 @@ describe("The payroll system", function () {
   })
 
   describe("process an Array of Arrays into an Array of employee records", function () {
-    it("has a function called createEmployees", function () {
-      expect(createEmployees).to.exist
+    it("has a function called createEmployeeRecords", function () {
+      expect(createEmployeeRecords).to.exist
     })
 
-    describe("createEmployees", function () {
+    describe("createEmployeeRecords", function () {
       let employeeRecords;
 
       let twoRows = [
@@ -51,12 +51,12 @@ describe("The payroll system", function () {
       ]
 
       it("creates two records", function () {
-        let employeeRecords = createEmployees(twoRows)
+        let employeeRecords = createEmployeeRecords(twoRows)
         expect(employeeRecords.length).to.equal(2)
       })
 
       it("correctly assigns the first names", function () {
-        let employeeRecords = createEmployees(twoRows)
+        let employeeRecords = createEmployeeRecords(twoRows)
         let nameExtractor = function (e) { return e.firstName }
         expect(employeeRecords.map(nameExtractor)).to.eql(["moe", "bartholomew"]);
       })
@@ -297,7 +297,7 @@ describe("The payroll system", function () {
           })
 
           it("correctly sums the payroll burden to $11,880 when passed an array of employee records", function () {
-            let employeeRecords = createEmployees(csvDataEmployees)
+            let employeeRecords = createEmployeeRecords(csvDataEmployees)
             employeeRecords.forEach(function (rec) {
               let timesInRecordRow = csvTimesIn.find(function (row) {
                 return rec.firstName === row[0]


### PR DESCRIPTION
The latter suggest an instance of a class. Not
desire when doing record-based work.